### PR TITLE
Missing efun and extra tests

### DIFF
--- a/func_spec.c
+++ b/func_spec.c
@@ -169,6 +169,7 @@ int	write_file(string, string);
 void    write_socket(string|int);
 void    write_socket_gmcp(string, mixed);
 string  val2json(mixed);
+mixed   json2val(string);
 void    set_ip_number(object, string);
 
 #ifdef WORD_WRAP

--- a/interpret.c
+++ b/interpret.c
@@ -2308,6 +2308,26 @@ f_val2json(int num_arg)
 
 /* ARGSUSED */
 static void
+f_json2val(int num_arg)
+{
+    struct svalue sval = *sp;
+    char *json = sval.u.string;
+    struct svalue *ret;
+    
+    ret = json2val(json);
+    pop_stack();
+    if (ret)
+    {
+        push_svalue(ret);
+    }
+    else
+    {
+        push_number(0);
+    }
+}
+
+/* ARGSUSED */
+static void
 f_str2val(int num_arg)
 {
     struct svalue sval = *sp;

--- a/main.c
+++ b/main.c
@@ -346,7 +346,7 @@ debug_message(char *fmt, ...)
     char *f;
 
     static FILE *fp = NULL;
-    char deb[100];
+    char deb[110];
     char name[100];
 
     if (fp == NULL) {

--- a/regress/expected.output
+++ b/regress/expected.output
@@ -10,8 +10,8 @@ Loading /tests/test-008.c -> Ok.
 Loading /tests/test-009.c -> Ok.
 Loading /tests/test-010.c -> Ok.
 Loading /tests/test-011.c -> *too many alarms in object
-Loading /tests/test-012.c -> tests/test-012.c: redefinition of variable 'i' line 7
-tests/test-012.c: Type mismatch ( int * vs int ) when initializing i line 7
+Loading /tests/test-012.c -> /tests/test-012.c: redefinition of variable 'i' line 7
+/tests/test-012.c: Type mismatch ( int * vs int ) when initializing i line 7
 *Error in loading object
 Loading /tests/test-013.c -> eval_cost too big 5000001 (/tests/test-013.c Line: 9)
 *Too long evaluation. Execution aborted.
@@ -19,24 +19,33 @@ Loading /tests/test-014.c -> Ok.
 Loading /tests/test-015.c -> Ok.
 Loading /tests/test-016.c -> Ok.
 Loading /tests/test-017.c -> Ok.
-Loading /tests/test-018.c -> tests/test-018.c: Function watchmecrashthisdriverwithareallyreallyreallyreallyreallreallyreallyreallyreallyreallyreallyreallyreallyreallreallylongfunctionnameohitneedstobereallyreallyreallylongofcoursebutIcandoityesicanithinkicanithinkicaniknowicaniknowcanhahahahahabutthisisreallyboringsozzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz line 9
+Loading /tests/test-018.c -> /tests/test-018.c: Function watchmecrashthisdriverwithareallyreallyreallyreallyreallreallyreallyreallyreallyreallyreallyreallyreallyreallreallylongfunctionnameohitneedstobereallyreallyreallylongofcoursebutIcandoityesicanithinkicanithinkicaniknowicaniknowcanhahahahahabutthisisreallyboringsozzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz line 9
 *Error in loading object
-Loading /tests/test-019.c -> tests/test-019.c: redefinition of variable 'vic' line 11
-tests/test-019.c: Incorrect number of arguments line 11
-tests/test-019.c: Incorrect number of arguments line 13
-tests/test-019.c: Function touch_me declared but never defined line 14
+Loading /tests/test-019.c -> /tests/test-019.c: redefinition of variable 'vic' line 11
+/tests/test-019.c: Incorrect number of arguments line 11
+/tests/test-019.c: Incorrect number of arguments line 13
+/tests/test-019.c: Function touch_me declared but never defined line 14
 *Error in loading object
 Loading /tests/test-020.c -> Ok.
 Loading /tests/test-021.c -> Ok.
 Loading /tests/test-022.c -> Ok.
-Loading /tests/test-023.c -> *Attempt to write empty string.
+Loading /tests/test-023.c -> *Bad argument 3 to write_bytes(), received type was Integer 
 Loading /tests/test-024.c -> Ok.
 Loading /tests/test-025.c -> Ok.
 Loading /tests/test-026.c -> Ok.
 Loading /tests/test-027.c -> *Too deep recursion
 Loading /tests/test-028.c -> Ok.
+Loading /tests/test-030.c -> program ref's 1
+Name tests/test-030.c
+program size 2782079
+num func's 1 (80) 
+sizeof rodata 31
+num vars 0 (0)
+num inherits 2 (48)
+total size 304
+Huge program size Ok.
 Setting up ipc.
 Listening to telnet port: 0.0.0.0:3011
-exec of hname failed.
 Listening to telnet port: :::3011
 Shutting down ipc...
+exec of hname failed.

--- a/regress/tests/test-026.c
+++ b/regress/tests/test-026.c
@@ -10,4 +10,9 @@ create()
 
     if (crypt("foo", "$1$BxY4Q1.U$") != "$1$BxY4Q1.U$CuizrialdJ9aeX30y/xJt/")
         throw("MD5 crypt is broken");
+
+    string pass = "foofoo!";
+    string c = crypt(pass, "$1$");
+    if (crypt(pass, c) != c)
+        throw("MD5 crypt is broken");
 }

--- a/regress/tests/test-030.c
+++ b/regress/tests/test-030.c
@@ -1,0 +1,16 @@
+/*
+ This is a test for a very big program sizes.
+ All the defines serve only to multiply number of opcodes in program, it does not really matter which opcodes.
+ Should pass after program-size fixes.
+*/ 
+
+#define L_1 (1|2|3|4|5|6|7|8|9|10|11|12|13|14|15|16|17|18|19|20)
+#define L_2 (L_1|L_1|L_1^L_1^L_1^L_1^L_1^L_1^L_1^L_1^L_1^L_1^L_1&L_1&L_1&L_1|L_1|L_1|L_1|L_1|L_1|L_1|L_1)
+#define L_3 (L_2|L_2|L_2|L_2|L_2|L_2|L_2|L_2|L_2|L_2|L_2|L_2|L_2|L_2|L_2)
+void
+create()
+{
+    int * a = ({L_3, L_3,L_3, L_3,L_3, L_3,L_3, L_3,L_3, L_3,L_3, L_3,L_3, L_3,L_3, L_3,L_3, L_3,L_3, L_3,L_3, L_3,L_3, L_3,L_3, L_3,L_3, L_3,L_3, L_3,L_3, L_3,L_3, L_3,L_3, L_3,L_3, L_3,L_3, L_3,L_3, L_3});
+    write(debug("object_info", 1, this_object()));
+    write("Huge program size ");
+}


### PR DESCRIPTION
This adds:
 - a missing efun (json2val), it existed in docs but now in code (strange)
 - extra tests in regress/: for extra big program size and one extra for crypt() as we has some issues with it previously.
 - one char[] allocation fix that was too small.