### PR TITLE
Fix `#define` parsing bug

### DIFF
--- a/lex.c
+++ b/lex.c
@@ -1909,7 +1909,7 @@ add_input(char *p)
     }
     outp -= l;
     nbuf += l;
-    strcpy(outp, p);
+    memcpy(outp, p, l);
 }
 
 #define DEFHASH 1999


### PR DESCRIPTION
Commit eb41365233c19537e2d2971cab0007780abfabaf introduced a bug in `#define` parsing wherein a null terminator would be written into the parse input stream after the expanded definition. The intention of the buggy commit was to eliminate a (wise) warning about using the source length as the buffer length in a `strncpy` operation; using memcpy here is probably the more-correct solution as we already know all the lengths involved.