### PR TITLE
Update Makefile to build driver for check

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -141,7 +141,7 @@ Makefile.depend: $(SRC) ${ISRC} make_func.c master.h lang.h efun_table.h prelang
 include Makefile.depend
 
 .PHONY: check
-check:
+check: all
 	sh regress.sh
 
 .PHONY: clean


### PR DESCRIPTION
Make the `check` tarMake the `check` target rely on the `driver` target so that `make check`
will both build and test.